### PR TITLE
Fix inverted skip_upload

### DIFF
--- a/pacman-bintrans-sign/src/main.rs
+++ b/pacman-bintrans-sign/src/main.rs
@@ -173,7 +173,7 @@ async fn main() -> Result<()> {
             }
         }
 
-        if args.skip_upload {
+        if !args.skip_upload {
             info!("Uploading to sigstore");
             match rekor_upload(&pk, pkg.sha256sum.as_bytes(), &sig).await {
                 Ok(_) => {


### PR DESCRIPTION
The signature should be uploaded if `skip_upload` is **not** set.